### PR TITLE
chore: update resume schema doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The FRESH resume schema is licensed under MIT. Go crazy.
 [f]: https://freshstandard.org
 [hmr]: https://fluentdesk.com/hackmyresume
 [fresh]: https://resume.freshstandard.org
-[schema]: schema/fresh-resume-schema.json
+[schema]: schema/fresh-resume-schema_1.0.0-beta.json
 [cli]: https://www.npmjs.com/package/fluentcv
 [fluentcv]: https://fluentdesk.com/fluentcv
 [jrs]: http://jsonresume.org


### PR DESCRIPTION
It currently 404s after commit 012ecdd780ce30ee2b9e077623dc00fb12f1470f.